### PR TITLE
Implemented bugfixes from private library from 2014.

### DIFF
--- a/Irony.Tests/StringLiteralTests.cs
+++ b/Irony.Tests/StringLiteralTests.cs
@@ -80,6 +80,9 @@ namespace Irony.Tests {
       Assert.IsTrue((string)token.Value == "00\a\b\t\n\v\f\r\"\\00", "Failed to process escaped characters.");
       token = parser.ParseInput(ReplaceQuotes("'abcd\nefg'  "));
       Assert.IsTrue(token.IsError(), "Failed to detect erroneous multi-line string.");
+      //With invalid escape
+      token = parser.ParseInput(ReplaceQuotes("\"\\d\""));
+      Assert.IsTrue(token.IsError(), "Failed to detect invalid escape sequence.");
       //with disabled escapes
       token = parser.ParseInput(ReplaceQuotes(@"@'00\a\b\t\n\v\f\r00'  "));
       Assert.IsTrue((string)token.Value == @"00\a\b\t\n\v\f\r00", "Failed to process @-string with disabled escapes.");
@@ -90,6 +93,8 @@ namespace Irony.Tests {
       Assert.IsTrue((string)token.Value == "abc@def", "Failed to process unicode escape \\u.");
       token = parser.ParseInput(ReplaceQuotes(@"'abc\U00000040def'  "));
       Assert.IsTrue((string)token.Value == "abc@def", "Failed to process unicode escape \\u.");
+      token = parser.ParseInput(ReplaceQuotes("\"\\u1\""));
+      Assert.IsTrue((string)token.Text == "\"\\u1\"", "Failed to process unicode escape \"\\u1\".");
       token = parser.ParseInput(ReplaceQuotes(@"'abc\x0040xyz'  "));
       Assert.IsTrue((string)token.Value == "abc@xyz", "Failed to process hex escape (4 digits).");
       token = parser.ParseInput(ReplaceQuotes(@"'abc\x040xyz'  "));

--- a/Irony/Parsing/Terminals/StringLiteral.cs
+++ b/Irony/Parsing/Terminals/StringLiteral.cs
@@ -313,6 +313,10 @@ namespace Irony.Parsing {
             arr[i] = newFirst + s.Substring(1);
           else {
             arr[i] = HandleSpecialEscape(arr[i], details);
+            // Checks for errors that were noted during handling of escape characters.
+            // This ensures that the parser correctly reports an error when encountering invalid escape sequences.
+            // See Codeplex issue #9897 (https://archive.codeplex.com/?p=irony)
+            if (!string.IsNullOrEmpty(details.Error)) return false;
           }//else
         }//for i
         value = string.Join(string.Empty, arr);
@@ -347,7 +351,10 @@ namespace Irony.Parsing {
           if (details.IsSet((short)StringOptions.AllowsUEscapes)) {
             len = (first == 'u' ? 4 : 8);
             if (segment.Length < len + 1) {
-              details.Error = string.Format(Resources.ErrBadUnEscape, segment.Substring(len + 1), len);// "Invalid unicode escape ({0}), expected {1} hex digits."
+              // Fixed Substring call which always failed. Instead, show details.Text. Original line commented out below.
+              // See Codeplex issue #9893 (https://archive.codeplex.com/?p=irony)
+              details.Error = string.Format(Resources.ErrBadUnEscape, details.Text, len);// "Invalid unicode escape ({0}), expected {1} hex digits."
+              //details.Error = string.Format(Resources.ErrBadUnEscape, segment.Substring(len + 1), len);// "Invalid unicode escape ({0}), expected {1} hex digits."
               return segment;
             }
             digits = segment.Substring(1, len);


### PR DESCRIPTION
Codeplex issue #9893:
Index out of range exception related to certain unicode escapes.

Codeplex issue #9897:
String.Literal.ConvertValue returns true on certain escape sequences even though they are invalid.