### PR TITLE
Set peverify-compat to ensure verifiable IL in C# 7.2 and up.

### DIFF
--- a/Irony/010.Irony.csproj
+++ b/Irony/010.Irony.csproj
@@ -7,6 +7,12 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>irony.snk</AssemblyOriginatorKeyFile>
+
+    <!--
+      This assembly is marked SecurityTransparent, which requires verifiable IL.
+      Setting peverify-compat ensures that the C# compiler will forgoe optimizations that would produce unverifiable IL.
+    -->
+    <Features>peverify-compat</Features>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Fixes #20.