### PR TITLE
Error location's line is calculated properly even when the newline character is only a carriage return ('\r') 

### DIFF
--- a/Irony.Tests/040.Irony.Tests.VsTest.csproj
+++ b/Irony.Tests/040.Irony.Tests.VsTest.csproj
@@ -88,6 +88,7 @@
     <Compile Include="IntegrationTests.cs" />
     <Compile Include="NumberLiteralTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="NewLineTests.cs" />
     <Compile Include="StringLiteralTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Irony.Tests/050.Irony.Tests.NUnit.csproj
+++ b/Irony.Tests/050.Irony.Tests.NUnit.csproj
@@ -89,6 +89,7 @@
     <Compile Include="NumberLiteralTests.cs" />
     <Compile Include="OperatorTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="NewLineTests.cs" />
     <Compile Include="RegExLiteralTests.cs" />
     <Compile Include="StringLiteralTests.cs" />
     <Compile Include="TestHelper.cs" />

--- a/Irony.Tests/NewLineTests.cs
+++ b/Irony.Tests/NewLineTests.cs
@@ -1,0 +1,57 @@
+using Irony.Parsing;
+
+namespace Irony.Tests {
+#if USE_NUNIT
+    using NUnit.Framework;
+    using TestClass = NUnit.Framework.TestFixtureAttribute;
+    using TestMethod = NUnit.Framework.TestAttribute;
+    using TestInitialize = NUnit.Framework.SetUpAttribute;
+#else
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+#endif
+
+  [TestClass]
+  public class NewLineTests
+  {
+
+    [TestMethod]
+    public void TestLineFeed() {
+      Parser parser; Token token;
+
+      NumberLiteral number = new NumberLiteral("Number");
+      parser = TestHelper.CreateParser(number);
+
+      token = parser.ParseInput("\n\n   word");
+      Assert.AreEqual(2, token.Location.Line, "Location line problem");
+      Assert.AreEqual(3, token.Location.Column, "Location column problem");
+      Assert.AreEqual(5, token.Location.Position, "Location position problem");
+    }//method
+
+    [TestMethod]
+    public void TestCarriageReturn() {
+      Parser parser; Token token;
+
+      NumberLiteral number = new NumberLiteral("Number");
+      parser = TestHelper.CreateParser(number);
+
+      token = parser.ParseInput("\r\r   word");
+      Assert.AreEqual(2, token.Location.Line, "Location line problem");
+      Assert.AreEqual(3, token.Location.Column, "Location column problem");
+      Assert.AreEqual(5, token.Location.Position, "Location position problem");
+    }//method
+
+    [TestMethod]
+    public void TestCarriageReturnPlusLineFeed() {
+      Parser parser; Token token;
+
+      NumberLiteral number = new NumberLiteral("Number");
+      parser = TestHelper.CreateParser(number);
+
+      token = parser.ParseInput("\r\n\r\n   word");
+      Assert.AreEqual(2, token.Location.Line, "Location line problem");
+      Assert.AreEqual(3, token.Location.Column, "Location column problem");
+      Assert.AreEqual(7, token.Location.Position, "Location position problem");
+    }//method
+
+  }//class
+}//namespace

--- a/Irony/Parsing/Scanner/SourceStream.cs
+++ b/Irony/Parsing/Scanner/SourceStream.cs
@@ -143,7 +143,7 @@ namespace Irony.Parsing {
         var curr = _chars[p];
         switch (curr) {
           case '\n': line++; col = 0; break;
-          case '\r': break; 
+          case '\r': if (p == _chars.Length - 1 || _chars[p + 1] != '\n') { line++; col = 0; }; break;
           case '\t': col = (col / _tabWidth + 1) * _tabWidth;     break;
           default: col++; break; 
         } //switch


### PR DESCRIPTION
fixes #49 