### PR TITLE
Create specific action for master push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,8 @@
 name: Build
 
 on:
-  pull_request:
+
+  push:
     branches: [ master ]
 
 jobs:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,24 @@
+name: PR
+
+on:
+
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
+    env:
+        DOTNET_NOLOGO: true
+        DOTNET_CLI_TELEMETRY_OPTOUT: 1
+
+    steps:
+    - name: Checkout source code
+      uses: actions/checkout@v4
+
+    - name: Test
+      run: dotnet test ./Irony.Tests/040.Irony.Tests.VsTest.csproj -c release


### PR DESCRIPTION
The badge in the README won't be affected by PR failures this way