### PR TITLE
Using string.IndexOf overload with StringComparison.Ordinal parameter

### DIFF
--- a/Irony/Parsing/Terminals/CommentTerminal.cs
+++ b/Irony/Parsing/Terminals/CommentTerminal.cs
@@ -86,7 +86,7 @@ namespace Irony.Parsing {
       while (!source.EOF()) {
         int firstCharPos;
         if (EndSymbols.Count == 1)
-          firstCharPos = source.Text.IndexOf(EndSymbols[0], source.PreviewPosition);
+          firstCharPos = source.Text.IndexOf(EndSymbols[0], source.PreviewPosition, StringComparison.Ordinal);
         else 
           firstCharPos = source.Text.IndexOfAny(_endSymbolsFirsts, source.PreviewPosition);
         if (firstCharPos < 0) {

--- a/Irony/Parsing/Terminals/FreeTextLiteral.cs
+++ b/Irony/Parsing/Terminals/FreeTextLiteral.cs
@@ -84,7 +84,7 @@ namespace Irony.Parsing {
     private Token TryMatchContentSimple(ParsingContext context, ISourceStream source) {
       var startPos = source.PreviewPosition;
       var termLen = _singleTerminator.Length;
-      var stringComp = Grammar.CaseSensitive ? StringComparison.InvariantCulture : StringComparison.InvariantCultureIgnoreCase;
+      var stringComp = Grammar.CaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
       int termPos = source.Text.IndexOf(_singleTerminator, startPos, stringComp);
       if (termPos < 0 && IsSet(FreeTextOptions.AllowEof))
         termPos = source.Text.Length;

--- a/Irony/Parsing/Terminals/QuotedValueLiteral.cs
+++ b/Irony/Parsing/Terminals/QuotedValueLiteral.cs
@@ -22,7 +22,7 @@ namespace Irony.Parsing {
     protected override string ReadBody(ParsingContext context, ISourceStream source) {
       if (!source.MatchSymbol(StartSymbol)) return null; //this will result in null returned from TryMatch, no token
       var start = source.Location.Position + StartSymbol.Length;
-      var end = source.Text.IndexOf(EndSymbol, start);
+      var end = source.Text.IndexOf(EndSymbol, start, StringComparison.Ordinal);
       if (end < 0) return null;
       var body = source.Text.Substring(start, end - start);
       source.PreviewPosition = end + EndSymbol.Length; //move beyond the end of EndSymbol

--- a/Irony/Parsing/Terminals/StringLiteral.cs
+++ b/Irony/Parsing/Terminals/StringLiteral.cs
@@ -185,7 +185,7 @@ namespace Irony.Parsing {
       int nlPos = lineBreakAllowed ? -1 : source.Text.IndexOf('\n', source.PreviewPosition);
       //fix by ashmind for EOF right after opening symbol
       while (true) {
-        int endPos = source.Text.IndexOf(endQuoteSymbol, source.PreviewPosition);
+        int endPos = source.Text.IndexOf(endQuoteSymbol, source.PreviewPosition, StringComparison.Ordinal);
         //Check for partial token in line-scanning mode
         if (endPos < 0 && details.PartialOk && lineBreakAllowed) {
           ProcessPartialBody(source, details); 
@@ -324,7 +324,7 @@ namespace Irony.Parsing {
 
       //Check for doubled end symbol
       string endSymbol = details.EndSymbol;
-      if (details.IsSet((short)StringOptions.AllowsDoubledQuote) && value.IndexOf(endSymbol) >= 0)
+      if (details.IsSet((short)StringOptions.AllowsDoubledQuote) && value.IndexOf(endSymbol, StringComparison.Ordinal) >= 0)
         value = value.Replace(endSymbol + endSymbol, endSymbol);
 
       if (details.IsSet((short)StringOptions.IsChar)) {

--- a/Irony/Parsing/Terminals/WikiTerminals/WikiBlockTerminal.cs
+++ b/Irony/Parsing/Terminals/WikiTerminals/WikiBlockTerminal.cs
@@ -26,7 +26,7 @@ namespace Irony.Parsing {
     public override Token TryMatch(ParsingContext context, ISourceStream source) {
       if (!source.MatchSymbol(OpenTag)) return null;
       source.PreviewPosition += OpenTag.Length;
-      var endPos = source.Text.IndexOf(CloseTag, source.PreviewPosition);
+      var endPos = source.Text.IndexOf(CloseTag, source.PreviewPosition, StringComparison.Ordinal);
       string content; 
       if(endPos > 0) {
         content = source.Text.Substring(source.PreviewPosition, endPos - source.PreviewPosition); 


### PR DESCRIPTION
It improves performance which has a regression in .NET (Core) since ICU is being used.
fixes #70 